### PR TITLE
feat: added lateral join support

### DIFF
--- a/joins.go
+++ b/joins.go
@@ -1,0 +1,85 @@
+package squirrel
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/lann/builder"
+)
+
+type fromSelectLateralPart struct {
+	sel   Sqlizer
+	alias string
+}
+
+func (p fromSelectLateralPart) ToSql() (string, []any, error) {
+	subSql, subArgs, err := p.sel.ToSql()
+	if err != nil {
+		return "", nil, err
+	}
+
+	sql := fmt.Sprintf("LATERAL (%s) AS %s", subSql, p.alias)
+	return sql, subArgs, nil
+}
+
+func (b SelectBuilder) FromSelectLateral(sel Sqlizer, alias string) SelectBuilder {
+	sel = forceQuestionPlaceholders(sel)
+	return builder.Set(b, "From", fromSelectLateralPart{sel: sel, alias: alias}).(SelectBuilder)
+}
+
+type joinLateralSelectPart struct {
+	joinType string // "JOIN", "LEFT JOIN", "CROSS JOIN"
+	sel      Sqlizer
+	alias    string
+	on       Sqlizer // nil for CROSS JOIN
+}
+
+func (p joinLateralSelectPart) ToSql() (string, []any, error) {
+	subSql, subArgs, err := p.sel.ToSql()
+	if err != nil {
+		return "", nil, err
+	}
+
+	var buf strings.Builder
+	_, _ = fmt.Fprintf(&buf, "%s LATERAL (%s) AS %s", p.joinType, subSql, p.alias)
+
+	args := subArgs
+	if p.on != nil {
+		onSql, onArgs, err := p.on.ToSql()
+		if err != nil {
+			return "", nil, err
+		}
+		_, _ = fmt.Fprintf(&buf, " ON %s", onSql)
+		args = append(args, onArgs...)
+	}
+
+	return buf.String(), args, nil
+}
+
+func (b SelectBuilder) JoinLateralSelect(sel Sqlizer, alias string, on Sqlizer) SelectBuilder {
+	sel = forceQuestionPlaceholders(sel)
+	part := joinLateralSelectPart{joinType: "JOIN", sel: sel, alias: alias, on: on}
+	return builder.Append(b, "Joins", part).(SelectBuilder)
+}
+
+func (b SelectBuilder) LeftJoinLateralSelect(sel Sqlizer, alias string, on Sqlizer) SelectBuilder {
+	sel = forceQuestionPlaceholders(sel)
+	part := joinLateralSelectPart{joinType: "LEFT JOIN", sel: sel, alias: alias, on: on}
+	return builder.Append(b, "Joins", part).(SelectBuilder)
+}
+
+func (b SelectBuilder) CrossJoinLateralSelect(sel Sqlizer, alias string) SelectBuilder {
+	sel = forceQuestionPlaceholders(sel)
+	part := joinLateralSelectPart{joinType: "CROSS JOIN", sel: sel, alias: alias, on: nil}
+	return builder.Append(b, "Joins", part).(SelectBuilder)
+}
+func forceQuestionPlaceholders(s Sqlizer) Sqlizer {
+	switch v := any(s).(type) {
+	case SelectBuilder:
+		return v.PlaceholderFormat(Question)
+	case CommonTableExpressionsBuilder:
+		return v.PlaceholderFormat(Question)
+	default:
+		return s
+	}
+}

--- a/joins_test.go
+++ b/joins_test.go
@@ -1,0 +1,145 @@
+package squirrel
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSelectBuilderFromSelectLateral(t *testing.T) {
+	subQ := Select("c").From("d").Where(Eq{"i": 0})
+
+	b := Select("a", "b").FromSelectLateral(subQ, "subq")
+
+	sql, args, err := b.ToSql()
+	assert.NoError(t, err)
+
+	expectedSql := "SELECT a, b FROM LATERAL (SELECT c FROM d WHERE i = ?) AS subq"
+	assert.Equal(t, expectedSql, sql)
+
+	expectedArgs := []any{0}
+	assert.Equal(t, expectedArgs, args)
+}
+
+func TestSelectBuilderFromSelectLateralNestedDollarPlaceholders(t *testing.T) {
+	subQ := Select("c").
+		From("t").
+		Where(Gt{"c": 1}).
+		PlaceholderFormat(Dollar)
+
+	b := Select("c").
+		FromSelectLateral(subQ, "subq").
+		Where(Lt{"c": 2}).
+		PlaceholderFormat(Dollar)
+
+	sql, args, err := b.ToSql()
+	assert.NoError(t, err)
+
+	expectedSql := "SELECT c FROM LATERAL (SELECT c FROM t WHERE c > $1) AS subq WHERE c < $2"
+	assert.Equal(t, expectedSql, sql)
+
+	expectedArgs := []any{1, 2}
+	assert.Equal(t, expectedArgs, args)
+}
+
+func TestSelectBuilderJoinLateralSelect(t *testing.T) {
+	postsForUser := Select("p.*").
+		From("posts p").
+		Where(Expr("p.user_id = u.id")).
+		OrderBy("p.id DESC").
+		Limit(3)
+
+	b := Select("u.id", "p.title").
+		From("users u").
+		JoinLateralSelect(postsForUser, "p", Expr("TRUE"))
+
+	sql, args, err := b.ToSql()
+	assert.NoError(t, err)
+
+	expectedSql := "SELECT u.id, p.title FROM users u JOIN LATERAL (SELECT p.* FROM posts p WHERE p.user_id = u.id ORDER BY p.id DESC LIMIT 3) AS p ON TRUE"
+	assert.Equal(t, expectedSql, sql)
+	assert.Empty(t, args)
+}
+
+func TestSelectBuilderLeftJoinLateralSelect(t *testing.T) {
+	subQ := Select("x.*").From("expensive_source x").Where(Expr("x.key = u.key")).Limit(1)
+
+	b := Select("u.id", "x.value").
+		From("users u").
+		LeftJoinLateralSelect(subQ, "x", Expr("TRUE")).
+		OrderBy("u.id ASC").
+		Limit(5).
+		Offset(10)
+
+	sql, args, err := b.ToSql()
+	assert.NoError(t, err)
+
+	expectedSql := "SELECT u.id, x.value FROM users u LEFT JOIN LATERAL (SELECT x.* FROM expensive_source x WHERE x.key = u.key LIMIT 1) AS x ON TRUE ORDER BY u.id ASC LIMIT 5 OFFSET 10"
+	assert.Equal(t, expectedSql, sql)
+
+	assert.Empty(t, args)
+}
+
+func TestSelectBuilderCrossJoinLateralSelect(t *testing.T) {
+	subQ := Select("g.n").From("generate_series(1, 3) g(n)")
+
+	b := Select("u.id", "g.n").
+		From("users u").
+		CrossJoinLateralSelect(subQ, "g")
+
+	sql, args, err := b.ToSql()
+	assert.NoError(t, err)
+
+	expectedSql := "SELECT u.id, g.n FROM users u CROSS JOIN LATERAL (SELECT g.n FROM generate_series(1, 3) g(n)) AS g"
+	assert.Equal(t, expectedSql, sql)
+	assert.Len(t, args, 0)
+}
+
+func TestSelectBuilderJoinLateralSelectNestedDollarPlaceholders(t *testing.T) {
+	inner := Select("c").
+		From("t").
+		Where(Gt{"c": 1}).
+		PlaceholderFormat(Dollar)
+
+	b := Select("u.id", "subq.c").
+		From("users u").
+		JoinLateralSelect(inner, "subq", Expr("TRUE")).
+		Where(Lt{"subq.c": 2}).
+		PlaceholderFormat(Dollar)
+
+	sql, args, err := b.ToSql()
+	assert.NoError(t, err)
+
+	expectedSql := "SELECT u.id, subq.c FROM users u JOIN LATERAL (SELECT c FROM t WHERE c > $1) AS subq ON TRUE WHERE subq.c < $2"
+	assert.Equal(t, expectedSql, sql)
+
+	expectedArgs := []any{1, 2}
+	assert.Equal(t, expectedArgs, args)
+}
+
+func TestSelectBuilderRawJoinLateral(t *testing.T) {
+	b := Select("u.id", "gs.n").
+		From("users u").
+		JoinLateralSelect(Expr("generate_series(1,3)"), "gs(n)", Expr("TRUE"))
+
+	sql, args, err := b.ToSql()
+	assert.NoError(t, err)
+
+	expectedSql := "SELECT u.id, gs.n FROM users u JOIN LATERAL (generate_series(1,3)) AS gs(n) ON TRUE"
+	assert.Equal(t, expectedSql, sql)
+	assert.Len(t, args, 0)
+}
+
+func TestSelectBuilderRawLeftAndCrossJoinLateral(t *testing.T) {
+	b := Select("u.id", "gs.n").
+		From("users u").
+		LeftJoinLateralSelect(Expr("generate_series(1,3)"), "gs(n)", Expr("TRUE")).
+		CrossJoinLateralSelect(Expr("generate_series(4,6)"), "gs2(n)")
+
+	sql, args, err := b.ToSql()
+	assert.NoError(t, err)
+
+	expectedSql := "SELECT u.id, gs.n FROM users u LEFT JOIN LATERAL (generate_series(1,3)) AS gs(n) ON TRUE CROSS JOIN LATERAL (generate_series(4,6)) AS gs2(n)"
+	assert.Equal(t, expectedSql, sql)
+	assert.Len(t, args, 0)
+}


### PR DESCRIPTION
This pull request adds support for SQL LATERAL joins and FROM clauses to the query builder, enabling advanced SQL queries involving subqueries that reference columns from preceding tables. It introduces new builder methods for `FROM LATERAL`, `JOIN LATERAL`, `LEFT JOIN LATERAL`, and `CROSS JOIN LATERAL`, along with comprehensive tests to ensure correct SQL generation and argument handling.

### LATERAL join and FROM clause support

* Added new methods to `SelectBuilder` for constructing `FROM LATERAL`, `JOIN LATERAL`, `LEFT JOIN LATERAL`, and `CROSS JOIN LATERAL` clauses, enabling subqueries that can reference columns from previous tables (`FromSelectLateral`, `JoinLateralSelect`, `LeftJoinLateralSelect`, `CrossJoinLateralSelect`).
* Implemented internal types (`fromSelectLateralPart`, `joinLateralSelectPart`) and logic to generate the correct SQL and handle arguments for these LATERAL clauses.
* Ensured that placeholder formats are correctly handled for nested queries by enforcing question mark placeholders within subqueries.

### Testing

* Added comprehensive tests in `joins_test.go` to verify correct SQL and argument generation for all new LATERAL join and FROM clause methods, including edge cases with nested placeholder formats and raw expressions.